### PR TITLE
Use namespace provided or defined for `kubectl`, `deploy` and `enter`

### DIFF
--- a/pkg/commands/deploy.go
+++ b/pkg/commands/deploy.go
@@ -56,11 +56,7 @@ func pullImageIfNotExists(image string) error {
 	return cmd.Run()
 }
 
-func runTemplater(folderIn, folderOut, templaterImage, namespace string, args cli.Args) error {
-	if namespace == "" {
-		namespace = "<ERROR_NAMESPACE_NOT_DEFINED_IN_THIS_ENV>"
-	}
-
+func runTemplater(folderIn, folderOut, templaterImage string, args cli.Args) error {
 	cfg, err := config.Read()
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)
@@ -145,7 +141,6 @@ func runTemplater(folderIn, folderOut, templaterImage, namespace string, args cl
 	os.Setenv("REGISTRY_HOST",registry)
 	os.Setenv("IMAGE_TAG", buildTag)
 	os.Setenv("PROJECT_DIR", provisioner.InClusterDir(shl.GetSanicRoot()))
-	os.Setenv("NAMESPACE", namespace)
 
 	for _, templatepath := range files {
 		templateName := strings.TrimSuffix(filepath.Base(templatepath), ".tmpl")
@@ -193,8 +188,13 @@ func createNamespace(namespace string, provisioner provisioner.Provisioner) erro
 	return nil
 }
 
-func kubectlApplyFolder(folder string, provisioner provisioner.Provisioner) error {
-	cmd, err := provisioner.KubectlCommand("apply", "-f", folder)
+func kubectlApplyFolder(folder, namespace string, provisioner provisioner.Provisioner) error {
+	var args []string
+	if namespace != "" {
+		args = append(args, "--namespace="+namespace)
+	}
+	args = append(args, "apply", "-f", folder)
+	cmd, err := provisioner.KubectlCommand(args...)
 	if err != nil {
 		return errors.Wrapf(err, "error while applying folder %s", folder)
 	}
@@ -247,7 +247,7 @@ func deployCommandAction(cliContext *cli.Context) error {
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)
 	}
-	err = runTemplater(folderIn, folderOut, cfg.Deploy.TemplaterImage, env.Namespace, cliContext.Args())
+	err = runTemplater(folderIn, folderOut, cfg.Deploy.TemplaterImage, cliContext.Args())
 	if err != nil {
 		return cli.NewExitError(fmt.Sprintf("could not compile templates: %s", err.Error()), 1)
 	}
@@ -260,7 +260,7 @@ func deployCommandAction(cliContext *cli.Context) error {
 			), 1)
 		}
 	}
-	err = kubectlApplyFolder(folderOut, provisioner)
+	err = kubectlApplyFolder(folderOut, env.Namespace, provisioner)
 	if err != nil {
 		return cli.NewExitError(fmt.Sprintf("could not apply templates in %s: %s", folderOut, err.Error()), 1)
 	}


### PR DESCRIPTION
If a namespace if provided as an argument for `kubectl` use that namespace for the command, default to namespace defined in `sanic.yaml.

If a namespace if provided as an argument for `deploy` create that namespace, default to namespace defined in `sanic.yaml`.

Use the namespace defined in `sanic.yaml` to enter pods.